### PR TITLE
Disable CSRF token validation

### DIFF
--- a/app/controllers/geniverse/application_controller.rb
+++ b/app/controllers/geniverse/application_controller.rb
@@ -4,7 +4,10 @@
 module Geniverse
   class ApplicationController < ::ApplicationController
     helper :all # include all helpers, all the time
-    protect_from_forgery # See ActionController::RequestForgeryProtection for details
+
+    # Disable CSRF token verification, since Geniverse actually is making cross site requests
+    # and relying on cookies by design.
+    skip_before_filter :verify_authenticity_token
 
     layout 'geniverse/application'
 

--- a/app/controllers/geniverse/users_controller.rb
+++ b/app/controllers/geniverse/users_controller.rb
@@ -7,13 +7,13 @@ module Geniverse
     # GET /users.xml
     def index
       if params[:username]
-        user = User.find_by_username(params[:username])
+        user = Geniverse::User.find_by_username(params[:username])
         @users = [user] if user
 
         # raise ActiveRecord::RecordNotFound, "Couldn't find user with username #{params[:username]}" unless @users
         @users = [] unless @users
       else
-         # @users = User.all
+         # @users = Geniverse::User.all
          @users = []
       end
 
@@ -29,9 +29,9 @@ module Geniverse
     # GET /users/1.xml
     def show
       if params[:id]
-        @user = User.find(params[:id])
+        @user = Geniverse::User.find(params[:id])
       else
-         @user = User.find_by_username(params[:username])
+         @user = Geniverse::User.find_by_username(params[:username])
          raise ActiveRecord::RecordNotFound, "Couldn't find user with username #{params[:username]}" unless @user
       end
 
@@ -45,7 +45,7 @@ module Geniverse
     # GET /users/new
     # GET /users/new.xml
     def new
-      @user = User.new
+      @user = Geniverse::User.new
 
       respond_to do |format|
         format.html # new.html.erb
@@ -55,7 +55,7 @@ module Geniverse
 
     # GET /users/1/edit
     def edit
-      @user = User.find(params[:id])
+      @user = Geniverse::User.find(params[:id])
     end
 
     # POST /users
@@ -65,7 +65,7 @@ module Geniverse
       user_params[:password_hash] = user_params[:passwordHash] if user_params.has_key? :passwordHash
       user_params.delete(:passwordHash)
 
-      @user = User.new(user_params)
+      @user = Geniverse::User.new(user_params)
 
       respond_to do |format|
         if @user.save
@@ -82,7 +82,7 @@ module Geniverse
     # PUT /users/1
     # PUT /users/1.xml
     def update
-      @user = User.find(params[:id])
+      @user = Geniverse::User.find(params[:id])
       respond_to do |format|
         attributes = paramify_json(params[:user])
         if @user.update_attributes(attributes)
@@ -99,7 +99,7 @@ module Geniverse
     # DELETE /users/1
     # DELETE /users/1.xml
     def destroy
-      @user = User.find(params[:id])
+      @user = Geniverse::User.find(params[:id])
       @user.destroy
 
       respond_to do |format|

--- a/app/models/geniverse.rb
+++ b/app/models/geniverse.rb
@@ -1,5 +1,0 @@
-module Geniverse
-  def self.table_name_prefix
-    'geniverse_'
-  end
-end

--- a/lib/geniverse.rb
+++ b/lib/geniverse.rb
@@ -2,4 +2,7 @@ require 'haml'
 require "geniverse/engine"
 
 module Geniverse
+  def self.table_name_prefix
+    'geniverse_'
+  end
 end


### PR DESCRIPTION
1. Fix this engine in dev mode.
2. Disable CSRF token validation.

Geniverse front-end sends various requests to Portal's Geniverse engine. I checked that `PUT /geniverse/users/27045.json` was causing session reset when this change wasn't present and CSRF token validation was enabled in main Portal (as expected). 

This change ensures that Geniverse works even if CSRF token validation is enabled in Portal. I tested it using mentioned path / request. There are more POST / PUT requests, but the fix has to affect all of them (as is defined in Geniverse::ApplicationController).